### PR TITLE
add healthcheck response for 200 OK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ axum = "0.8.8"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 dotenvy = "0.15"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/handlers/index.rs
+++ b/src/handlers/index.rs
@@ -1,9 +1,35 @@
+use axum::{Json, http::StatusCode, extract::State};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::AppState;
+
 pub async fn get_token_validate() -> &'static str {
     "Your token has been validated."
 }
 
-pub async fn get_health() -> &'static str {
-    "Healthy!"
+#[derive(Serialize, Deserialize)]
+pub struct Healthcheck {
+    status: String,
+    version: String,
+    uptime: String,
+}
+
+pub async fn get_health(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Healthcheck>) {
+    let uptime_duration = Utc::now().signed_duration_since(state.start_time);
+    let uptime_seconds = uptime_duration.num_seconds();
+    let uptime = format!("{} seconds", uptime_seconds);
+
+    (
+        StatusCode::OK,
+        Json(Healthcheck {
+            status: "Healthy!".to_string(),
+            // TODO: use a function that gets semver from somewhere else
+            version: "0.0.1".to_string(),
+            uptime,
+        }),
+    )
 }
 
 pub async fn post_token_exchange() -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,23 @@
 use axum::{Router, routing::get, routing::post};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
 
 mod config;
 mod handlers;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub start_time: DateTime<Utc>,
+}
 
 #[tokio::main]
 async fn main() {
     let config = config::Config::load();
     let addr = format!("{}:{}", config.server_host, config.server_port);
+
+    let state = Arc::new(AppState {
+        start_time: Utc::now(),
+    });
 
     let app = Router::new()
         .route("/", get(|| async { "Smart on FHIR Token Broker" }))
@@ -15,7 +26,8 @@ async fn main() {
         .route(
             "/token/exchange",
             post(handlers::index::post_token_exchange),
-        );
+        )
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();


### PR DESCRIPTION
## PR Description: Implement Health Endpoint with Uptime

This PR implements the `GET /health` endpoint for readiness/liveness checks, addressing [issue #3](https://github.com/Shua-myers/smart-fhir-token-broker-rs/issues/3).

### Changes Made

#### Dependencies
- **Cargo.toml**: Added `chrono` crate with serde features for date/time handling.

#### Application State
- **src/main.rs**: 
  - Introduced `AppState` struct to track application start time.
  - Modified `main()` to record start time and inject state into the Axum router.

#### Health Endpoint
- **src/handlers/index.rs**:
  - Updated imports to include Axum state extraction and chrono utilities.
  - Refactored `get_health()` handler to:
    - Accept application state via dependency injection.
    - Calculate uptime as the duration since application start.
    - Return a JSON response with `status`, `version`, and `uptime` fields.
  - Added `Healthcheck` struct for the response payload.

### API Response
The endpoint now returns HTTP 200 with the following JSON:
```json
{
  "status": "Healthy!",
  "version": "0.0.1",
  "uptime": "123 seconds"
}